### PR TITLE
fix(*): Fix GPS not enable in some device manufacturers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ example/ios/Runner/Info.plist
 example/ios/Runner.xcodeproj/project.pbxproj
 android/.classpath
 example/android/.gradle/*
+*.flutter-plugins-dependencies

--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -348,6 +348,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler, PluginR
         LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
         builder.addLocationRequest(mLocationRequest);
         mLocationSettingsRequest = builder.build();
+        builder.setAlwaysShow(true);
     }
 
     /**


### PR DESCRIPTION
LocationSettingsRequest.Builder has a method setAlwaysShow(boolean show). Setting builder.setAlwaysShow(true); will enable GPS through out the phone.